### PR TITLE
fix: 修复高DPI移动设备图片导出时文字排版被挤压的问题

### DIFF
--- a/src/components/ResultCard.vue
+++ b/src/components/ResultCard.vue
@@ -187,8 +187,12 @@ const exportCard = async () => {
       throw new Error('Result card not found')
     }
 
-    // Use the basic usage pattern from snapdom docs
-    const result = await snapdom(card)
+    const result = await snapdom(card, {
+      width: 720,
+      scale: 2,
+      dpr: 1,
+      backgroundColor: '#fff'
+    })
     const img = await result.toPng()
     
     const link = document.createElement('a')


### PR DESCRIPTION
## 问题描述

修复 #1 - 高 DPI 移动设备（如 Pixel 8）上导出图片时文字排版被挤压的问题。

## 根本原因

在高 DPI 移动设备上，snapdom 默认使用 `devicePixelRatio` 进行截图，但卡片使用响应式布局，导致：
- 移动端卡片宽度被压缩（远小于设计的 720px）
- 弹性布局中的文字标签被挤压
- 导出的图片保留了压缩后的布局状态

## 修复方案

为 `snapdom()` 添加固定参数配置：

| 参数 | 值 | 作用 |
|------|-----|------|
| `width` | 720 | 强制以 720px 宽度渲染，避免响应式布局压缩 |
| `scale` | 2 | 2 倍缩放，输出 1440px 宽的高清图片 |
| `dpr` | 1 | 固定设备像素比，确保所有设备输出一致 |
| `backgroundColor` | #fff | 确保背景色一致 |

## 测试验证

- [x] 设备测试通过
- [x] 导出图片文字排版正常，不再被挤压


![2ff32b06fe2b824fdb7778af7a7238b4_720](https://github.com/user-attachments/assets/8e726e3a-dd79-4f71-9526-2be142c26183)

